### PR TITLE
add new options: disable all chat room, disable some xmpp ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 * set roomname to topic if roomname is not defined
 * option to preserve changed name of room
 
-next: option to define a list of xmpp users which won't be mapped to a matrix room
-then: pull request to anewusername
+* next: option to define a list of xmpp users which won't be mapped to a matrix room.
+* then: pull request to anewusername
 
 ## original readme by anewusername
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
 * set roomname to topic if roomname is not defined
 * option to preserve changed name of room
 
+next: option to define a list of xmpp users which won't be mapped to a matrix room
+then: pull request to anewusername
+
 ## original readme by anewusername
 
 I wrote this bot to finally get persistent chat history for my 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 * add option to disable all_chat room completely
 * set roomname to topic if roomname is not defined
 * option to preserve changed name of room
+* option to define a list of xmpp users which won't be mapped to a matrix room (disabled_jid)
 
 ## original readme by anewusername
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 **mxpp** is a bot which bridges Matrix and one-to-one XMPP chat.
 
+### edits by lugino-emeritus:
+
+* solved bug when sending a message like "joinmuc" (without room name) in control room
+* add option to disable all_chat room completely
+* set roomname to topic if roomname is not defined
+* option to preserve changed name of room
+
+## original readme by anewusername
+
 I wrote this bot to finally get persistent chat history for my 
 gchat/hangouts/google talk conversations, and to evaluate Matrix
 for future use, so it should probably work for those use cases.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,6 @@
 * option to preserve changed name of room
 * option to define a list of xmpp users which won't be mapped to a matrix room (disabled_jid)
 
-* next: option to define a list of xmpp users which won't be mapped to a matrix room.
-* then: pull request to anewusername
-
 ## original readme by anewusername
 
 I wrote this bot to finally get persistent chat history for my 

--- a/config.yaml
+++ b/config.yaml
@@ -60,3 +60,7 @@ disable_all_chat_room: true
 
 # Ignore any groupchat messages that were sent by our own nick
 groupchat_mute_own_nick: true
+
+# do not connect to following xmpp users; value xmpp_login_jid is also allowed and would be replaced with the xmpp login jid
+disabled_jids:
+  - xmpp_login_jid

--- a/config.yaml
+++ b/config.yaml
@@ -25,7 +25,7 @@ matrix:
   #   (e.g. <>*&') so that it won't ever be confused for a JID
   groupchat_flag: '<groupchat>'
   
-  # should be false, when you want to set names of rooms
+  # should be false when you want to set names of rooms
   restore_room_topic: true
 
 
@@ -54,6 +54,9 @@ send_presences_to_control: true
 
 # Send a copy of all messages to the all_chat channel
 send_messages_to_all_chat: true
+
+#only used if send_messages_to_all_chat is false
+disable_all_chat_room: true
 
 # Ignore any groupchat messages that were sent by our own nick
 groupchat_mute_own_nick: true

--- a/config.yaml
+++ b/config.yaml
@@ -24,6 +24,9 @@ matrix:
   #  Ideally, this should include some characters which are illegal in JIDs
   #   (e.g. <>*&') so that it won't ever be confused for a JID
   groupchat_flag: '<groupchat>'
+  
+  # should be false, when you want to set names of rooms
+  restore_room_topic: true
 
 
 xmpp:

--- a/mxpp/main.py
+++ b/mxpp/main.py
@@ -125,14 +125,14 @@ class BridgeBot:
         self.users_to_invite = config['matrix']['users_to_invite']
         self.matrix_room_topics = config['matrix']['room_topics']
         self.groupchat_flag = config['matrix']['groupchat_flag']
-        if 'restore_room_topic' in config['matrix']:
+        if 'restore_room_topic' in config['matrix']: #to be compatible to other config files
             self.restore_room_topic = config['matrix']['restore_room_topic']
 
         self.matrix_server = config['matrix']['server']
         self.matrix_login = config['matrix']['login']
         self.xmpp_server = (config['xmpp']['server']['host'],
                             config['xmpp']['server']['port'])
-        self.xmpp_login = config['xmpp']['login'] #to be compatible to other config files
+        self.xmpp_login = config['xmpp']['login']
         self.xmpp_groupchat_nick = config['xmpp']['groupchat_nick']
 
         self.send_presences_to_control = config['send_presences_to_control']

--- a/mxpp/main.py
+++ b/mxpp/main.py
@@ -209,7 +209,7 @@ class BridgeBot:
         :param name: (Optional) Name for the new room
         :return: Room which was created
         """
-        if not name: #room without name is shown as the bot's name in riot -> not nice
+        if not name: #room without name is shown as the bot's name in clients like riot
             name = topic
 
         if topic in self.groupchat_jids:


### PR DESCRIPTION
Hello anewusername,
your bot works really fine, I added some new options (all could be defined in the config file)
- don't change name of matrix room
- set room name to topic if room name is not defined
- disable all_chat room completely
- define a list with xmpp users which shouldn't be mapped to a matrix room

Maybe you want to add it to your branch:)